### PR TITLE
Multiple clients

### DIFF
--- a/mongodb_bundle/bundle.py
+++ b/mongodb_bundle/bundle.py
@@ -1,16 +1,40 @@
+from typing import Any, Dict, List, Optional, Union
+
 from pymongo import MongoClient
 from pydantic import BaseModel
 from dependency_injector import containers, providers
 from applauncher.applauncher import Configuration
 
 
-class MongoDBConfig(BaseModel):
+class BaseMongoURI(BaseModel):
     uri: str
     connect: bool = True
 
 
+class NamedMongoURI(BaseMongoURI):
+    name: str
+
+
+class MongoDBConfig(BaseMongoURI):
+    uris: Optional[List[NamedMongoURI]]
+
+
 def get_default_database(client: MongoClient):
     return client.get_default_database()
+
+
+class MongoClientsContainer:
+    def __init__(self, named_uris: List[Dict[str, Any]]):
+        self._uris = {u.name: {'uri': u.uri, 'connect': u.connect} for u in named_uris}
+
+    def __getitem__(self, conn_name: str) -> MongoClient:
+        uri = self._uris[conn_name]
+        return MongoClient(host=uri['uri'], connect=uri['connect'])
+
+    def get(self, conn_name: str, default: Any = None) -> Union[MongoClient, Any]:
+        if conn_name not in self._uris:
+            return default
+        return self.__getitem__(conn_name)
 
 
 class MongoDBContainer(containers.DeclarativeContainer):
@@ -25,6 +49,11 @@ class MongoDBContainer(containers.DeclarativeContainer):
     db = providers.Callable(
         get_default_database,
         mongo_client
+    )
+
+    clients = providers.Callable(
+        MongoClientsContainer,
+        named_uris=configuration.provided.mongodb.uris
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mongodb-bundle"
-version = "2.0.2"
+version = "2.1.0"
 description = "Mongodb support for applauncher"
 authors = ["Alvaro Garcia <maxpowel@gmail.com>"]
 


### PR DESCRIPTION
Add support for multiple clients so they can authenticate with different credentials or on different databases.
The default behaviour is still available, the multiple clients are optional.